### PR TITLE
MethodCZT update

### DIFF
--- a/src/PSF_types.jl
+++ b/src/PSF_types.jl
@@ -14,6 +14,8 @@ struct MethodPropagateIterative<: PSFMethod end
 struct MethodRichardsWolf <: PSFMethod end
 struct MethodShell <: PSFMethod end
 struct MethodParaxial <: PSFMethod end
+struct MethodCZT <: PSFMethod end
+
 
 export Aberrations
 export Zernike_Piston, Zernike_Tilt, Zernike_Tip, Zernike_ObliqueAstigmatism, Zernike_Defocus, Zernike_VerticalAstigmatism, Zernike_VerticalTrefoil
@@ -167,6 +169,8 @@ Arguments:
     + MethodSincR: Based on first calculating a SincR function in real space and applying consecutive filtering steps. It accounts for wrap around problems but requires a quite high sampling along the Z direction.
     + MethodRichardsWolf: Uses the method described in the paper by B. Richards and E. Wolf, "Electromagnetic diffraction in optical systems. II. structure of the image field in an aplanatic system," Proc. R. Soc. London A, vol. 253, no. 1274, 1959.
                             The terms I0, I1 and I2 are first calculated for an radial Z-dependet profile and then interpolated onto the 3D volume.
+    + MethodCZT: Angulare spectrum propagation. Using the CZT to avoid or reduce wrap-around effect of FFT. The method involves the pupil fully covering the range and CZT zooming in. Set a flexible plan zoom factor C_xy >1  in the function
+
 + aplanatic:    aplanatic factor. Provided as a function of angle θ. Choices are `aplanatic_const`, `aplanatic_detection`, `aplanatic_illumination`, `aplanatic_illumination_flux`
 + FFTPlan:      information on how to calculate the FFTW plan. Default: nothing (using FFTW.ESTIMATE)
 + transition_dipole  If supplied a transition-dipole (e.g. sqrt(2) .* (0.0,1.0,1.0)) will be accounted for in the PSF calculation. If not normalized, the strength will be included.

--- a/src/PointSpreadFunctions.jl
+++ b/src/PointSpreadFunctions.jl
@@ -8,7 +8,7 @@ export kz_mid_pos
 export modify_STED_exp, modify_STED_hyper, modify_ident, modify_square
 
 export ModeWidefield, ModeConfocal, Mode4Pi, ModeISM, Mode2Photon, ModeSTED, ModeLightsheet
-export MethodRichardsWolf, MethodPropagate, MethodPropagateIterative, MethodShell, MethodSincR
+export MethodRichardsWolf, MethodPropagate, MethodPropagateIterative, MethodShell, MethodSincR, MethodCZT
 
 include("aplanatic.jl")
 include("PSF_types.jl")

--- a/src/TestCZT.jl
+++ b/src/TestCZT.jl
@@ -1,0 +1,17 @@
+using PointSpreadFunctions
+using Revise
+
+
+λ_em = 0.5; NA = 1.4; n = 1.52
+λ_ex = 0.488 # only needed for some PointSpreadFunctions, such as confocal, ISM or TwoPhoton
+
+
+sz = (256, 256, 256)
+sampling = (0.050,0.050,0.050)
+#print(pp)
+#println("Is PointSpreadFunctions loaded? ", isdefined(Main, :PointSpreadFunctions))
+#println("Is MethodCZT available? ", isdefined(PointSpreadFunctions, :MethodCZT))
+
+pp1 = PSFParams(λ_em, NA, n; method= MethodCZT);@time p_czt = psf(sz, pp1; sampling=sampling)
+pp2 = PSFParams(λ_em, NA, n; method= MethodRichardsWolf); @time p_RW = psf(sz, pp2; sampling=sampling)
+#Compare the calculation time of APSF using Method CZT and Method Richards-Wolf.


### PR DESCRIPTION
I wrote a function to calculate APSF using the CZT method (where the pupil fully covers the range and CZT zooms in) in apsf.jl:


        function apsf(::Type{MethodCZT}, sz::NTuple, pp::PSFParams; sampling=nothing, center_kz=false)...

The code runs well in examples\PSFs_demo.ipynb and the CZT method is applied successfully and set a flexible plan zoom factor C_xy >1  in the function according the thesis by Ratsimandresy Holinirina Dina Miora.

I wrote a TestCZT.jl file in the folder src to compare the calculation time of APSF using Method CZT and Method Richards-Wolf.

I add the defination of MethodCZT in PSF_types.jl: line172.
![TestCZT](https://github.com/RainerHeintzmann/PointSpreadFunctions.jl/assets/167460260/4cf1593b-4aef-43bc-a1bc-fa9a1f37c10e)

