### PR TITLE
Type Error in ZernikePolynomials.jl

### DIFF
--- a/src/pupil.jl
+++ b/src/pupil.jl
@@ -146,7 +146,7 @@ function get_Zernike_normcoeff(index_style, j)
             error("Unknown Zernike sequential index")
         end
     end
-    return normalization(n,m) # The normalization of the Zernike toolbox is according to Thibos et al. - "Standards for Reporting the Optical Aberrations of Eyes"
+    return normalization(Int64(n),Int64(m)) # The normalization of the Zernike toolbox is according to Thibos et al. - "Standards for Reporting the Optical Aberrations of Eyes"
 end
 
 """


### PR DESCRIPTION
The 'normalization' function in ZernikePolynomials.jl was changed and does not accept Int8 input anymore, causing an error when calling it from PointSpreadFunctions.jl

Solution: Convert input arguments to expected Int64 before call.